### PR TITLE
envoy gateway install

### DIFF
--- a/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
+++ b/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/config/dependencies/envoy-gateway/gateway/gateway.yaml
+++ b/config/dependencies/envoy-gateway/gateway/gateway.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eg
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80

--- a/config/dependencies/envoy-gateway/gateway/kustomization.yaml
+++ b/config/dependencies/envoy-gateway/gateway/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# Adds namespace to all resources.
+namespace: envoy-gateway-system
+resources:
+- gateway-class.yaml
+- gateway.yaml

--- a/config/dependencies/envoy-gateway/kustomization.yaml
+++ b/config/dependencies/envoy-gateway/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+- https://github.com/envoyproxy/gateway/releases/download/v1.0.0/install.yaml

--- a/make/envoy-gateway.mk
+++ b/make/envoy-gateway.mk
@@ -1,0 +1,45 @@
+
+##@ Envoy Gateway
+
+## Targets to help install and configure EG
+
+EG_CONFIG_DIR = config/dependencies/envoy-gateway
+EG_NAMESPACE = envoy-gateway-system
+
+# egctl tool
+EGCTL=$(PROJECT_PATH)/bin/egctl
+EG_VERSION = v1.0.0
+OS = linux
+ARCH = amd64
+$(EGCTL):
+	mkdir -p $(PROJECT_PATH)/bin
+	## get-egctl.sh requires sudo and does not allow installing in a custom location. Fails if not in the PATH as well
+	# curl -sSL https://gateway.envoyproxy.io/get-egctl.sh | EGCTL_INSTALL_DIR=$(PROJECT_PATH)/bin  VERSION=$(EG_VERSION) bash
+	$(eval TMP := $(shell mktemp -d))
+	cd $(TMP); curl -sSL https://github.com/envoyproxy/gateway/releases/download/$(EG_VERSION)/egctl_$(EG_VERSION)_$(OS)_$(ARCH).tar.gz -o egctl.tar.gz
+	tar xf $(TMP)/egctl.tar.gz -C $(TMP)
+	cp $(TMP)/bin/$(OS)/$(ARCH)/egctl $(EGCTL)
+	-rm -rf $(TMP)
+
+.PHONY: egctl
+egctl: $(EGCTL) ## Download egctl locally if necessary.
+
+.PHONY: envoy-gateway-install
+envoy-gateway-install: kustomize
+	$(KUSTOMIZE) build $(EG_CONFIG_DIR) | kubectl apply -f -
+	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+
+.PHONY: envoy-gateway-uninstall
+envoy-gateway-uninstall: kustomize ## Uninstall envoy gateway.
+	$(KUSTOMIZE) build $(EG_CONFIG_DIR) | kubectl delete -f -
+
+.PHONY: deploy-eg-gateway
+deploy-eg-gateway: kustomize ## Deploy Gateway API gateway
+	$(KUSTOMIZE) build $(EG_CONFIG_DIR)/gateway | kubectl apply -f -
+	kubectl wait --timeout=5m -n envoy-gateway-system gateway/eg --for=condition=Programmed
+	@echo
+	@echo "-- Linux only -- Ingress gateway is exported using loadbalancer service in port 80"
+	@echo "export INGRESS_HOST=\$$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}')"
+	@echo "export INGRESS_PORT=\$$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.spec.listeners[?(@.name==\"http\")].port}')"
+	@echo "Now you can hit the gateway:"
+	@echo "curl --verbose --resolve www.example.com:\$${INGRESS_PORT}:\$${INGRESS_HOST} http://www.example.com:\$${INGRESS_PORT}/get"


### PR DESCRIPTION
Howto
```
make local-env-setup
```
That install envoy gateway controller, Gateway API CRDs, one gateway managed by EG and all kuadrant dependencies in Kind (kuadrant no installed)

Let's hit that gateway (the steps only work on linux)

```sh
INGRESS_HOST=$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}')
INGRESS_PORT=$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
```

```sh
curl --verbose --resolve www.example.com:${INGRESS_PORT}:${INGRESS_HOST} http://www.example.com:${INGRESS_PORT}/get
```
The expected response is 404 (no route yet)

```
* Added www.example.com:80:172.18.0.252 to DNS cache
* Hostname www.example.com was found in DNS cache
*   Trying 172.18.0.252:80...
* Connected to www.example.com (172.18.0.252) port 80 (#0)
> GET /get HTTP/1.1
> Host: www.example.com
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< date: Fri, 12 Apr 2024 09:28:19 GMT
< content-length: 0
< 
* Connection #0 to host www.example.com left intact
```


